### PR TITLE
Update metrics for BraTS-Aug 2024

### DIFF
--- a/evaluation/lesionwise/score_aug.py
+++ b/evaluation/lesionwise/score_aug.py
@@ -12,9 +12,11 @@ import argparse
 import json
 
 import pandas as pd
+import numpy as np
 import synapseclient
+
 import utils
-import lesionwise_eval
+from brats2023_metrics import metrics as lesionwise_eval
 
 
 def get_args():

--- a/evaluation/lesionwise/score_aug.py
+++ b/evaluation/lesionwise/score_aug.py
@@ -110,13 +110,10 @@ def main():
     results = score(dir_name, preds, args.label)
 
     # Get number of segmentations predicted by participant, as well as
-    # descriptive statistics for results.
+    # the mean and GINI-index.
     cases_evaluated = len(results.index)
-    metrics = (results
-               .describe()
-               .rename(index={'25%': "25quantile", '50%': "median", '75%': "75quantile"})
-               .drop(["count", "min", "max"]))
-    metrics.loc["variance"] = results.var()
+    metrics = pd.DataFrame({"mean": results.mean()}).T
+    metrics.loc["gini"] = results.agg(gini)
     results = pd.concat([results, metrics])
 
     # CSV file of scores for all scans.
@@ -137,13 +134,13 @@ def main():
                              'Hausdorff95_TC': "Hausdorff95_TC_mean",
                              'Hausdorff95_WT': "Hausdorff95_WT_mean", }),
                     **results
-                    .loc["variance"]
-                    .rename({'Dice_ET': "Dice_ET_var",
-                             'Dice_TC': "Dice_TC_var",
-                             'Dice_WT': "Dice_WT_var",
-                             'Hausdorff95_ET': "Hausdorff95_ET_var",
-                             'Hausdorff95_TC': "Hausdorff95_TC_var",
-                             'Hausdorff95_WT': "Hausdorff95_WT_var", }),
+                    .loc["gini"]
+                    .rename({'Dice_ET': "Dice_ET_gini",
+                             'Dice_TC': "Dice_TC_gini",
+                             'Dice_WT': "Dice_WT_gini",
+                             'Hausdorff95_ET': "Hausdorff95_ET_gini",
+                             'Hausdorff95_TC': "Hausdorff95_TC_gini",
+                             'Hausdorff95_WT': "Hausdorff95_WT_gini", }),
                     "cases_evaluated": cases_evaluated,
                     "submission_scores": csv.id,
                     "submission_status": "SCORED"}

--- a/evaluation/lesionwise/score_aug.py
+++ b/evaluation/lesionwise/score_aug.py
@@ -47,6 +47,17 @@ def calculate_per_lesion(pred, gold, label):
     )
 
 
+def gini(x):
+    """Algorithm for GINI index metric (credit: @chepyle)."""
+    sorted_x = np.sort(x)
+    n = len(x)
+    cumx = np.cumsum(sorted_x, dtype=float)
+    index = (n + 1 - 2 * np.sum(cumx) / cumx[-1]) / n
+    if np.isnan(index):
+        return 1.0
+    return index
+
+
 def extract_metrics(df, label, scan_id):
     """Get scores for three regions: ET, WT, and TC.
 


### PR DESCRIPTION
Fixes #4 

## Changelog
* Add GINI-index computation function (courtesy of @chepyle)
* Add GINI-index metric to scores file as `gini`
* Remove `variance`, `std`, `median`, `25quantile` and `75quantile` stats from scores file

## Code preview

Where `results` is a dataframe consisting of full Dice and HD95 scores as calculated by Rachit's lesionwise evaluation script.

```python
>>> def gini(x):
...     """Algorithm for GINI index metric (credit: @chepyle)."""
...     sorted_x = np.sort(x)
...     n = len(x)
...     cumx = np.cumsum(sorted_x, dtype=float)
...     index = (n + 1 - 2 * np.sum(cumx) / cumx[-1]) / n
...     if np.isnan(index):
...         return 1.0
...     return index
... 
>>> 
>>> cases_evaluated = len(results.index)
>>> metrics = pd.DataFrame({"mean": results.mean()}).T
>>> metrics.loc["gini"] = results.agg(gini)
[WARNING] <stdin>:6: RuntimeWarning: invalid value encountered in scalar divide

>>> results = pd.concat([results, metrics])
>>> results
                     Dice_ET  Dice_TC  Dice_WT  Hausdorff95_ET  Hausdorff95_TC  Hausdorff95_WT  Sensitivity_ET  Sensitivity_TC  Sensitivity_WT  Specificity_ET  Specificity_TC  Specificity_WT
BraTS-GLI-00001-000      1.0      1.0      1.0             0.0             0.0             0.0             1.0             1.0             1.0             1.0             1.0             1.0
BraTS-GLI-00001-001      1.0      1.0      1.0             0.0             0.0             0.0             1.0             1.0             1.0             1.0             1.0             1.0
BraTS-GLI-00013-000      1.0      1.0      1.0             0.0             0.0             0.0             1.0             1.0             1.0             1.0             1.0             1.0
BraTS-GLI-00013-001      1.0      1.0      1.0             0.0             0.0             0.0             1.0             1.0             1.0             1.0             1.0             1.0
BraTS-GLI-00015-000      1.0      1.0      1.0             0.0             0.0             0.0             1.0             1.0             1.0             1.0             1.0             1.0
mean                     1.0      1.0      1.0             0.0             0.0             0.0             1.0             1.0             1.0             1.0             1.0             1.0
gini                     0.0      0.0      0.0             1.0             1.0             1.0             0.0             0.0             0.0             0.0             0.0             0.0
```

@chepyle do the final results and format look OK to you?  This dataframe is what will be uploaded to Synapse for the participants.

Also, do you think that RuntimeWarning is safe to ignore?  I figured I received that on my end because I had used the validation GT as my "test" submission.

As for the validation leaderboard, each submission will contain these annotations:

```python
>>> res_dict = {
...     **results.loc["mean"]
...     .rename({'Dice_ET': "Dice_ET_mean",
...                 'Dice_TC': "Dice_TC_mean",
...                 'Dice_WT': "Dice_WT_mean",
...                 'Hausdorff95_ET': "Hausdorff95_ET_mean",
...                 'Hausdorff95_TC': "Hausdorff95_TC_mean",
...                 'Hausdorff95_WT': "Hausdorff95_WT_mean", }),
...     **results.loc["gini"]
...     .rename({'Dice_ET': "Dice_ET_gini",
...                 'Dice_TC': "Dice_TC_gini",
...                 'Dice_WT': "Dice_WT_gini",
...                 'Hausdorff95_ET': "Hausdorff95_ET_gini",
...                 'Hausdorff95_TC': "Hausdorff95_TC_gini",
...                 'Hausdorff95_WT': "Hausdorff95_WT_gini", }),
...     "cases_evaluated": cases_evaluated,
...     "submission_status": "SCORED"
... }
>>> print(res_dict)
{
    'Dice_ET_mean': 1.0,
    'Dice_TC_mean': 1.0,
    'Dice_WT_mean': 1.0,
    'Hausdorff95_ET_mean': 0.0,
    'Hausdorff95_TC_mean': 0.0,
    'Hausdorff95_WT_mean': 0.0,
    'Sensitivity_ET': 0.0,
    'Sensitivity_TC': 0.0,
    'Sensitivity_WT': 0.0,
    'Specificity_ET': 0.0,
    'Specificity_TC': 0.0,
    'Specificity_WT': 0.0,
    'Dice_ET_gini': 0.0,
    'Dice_TC_gini': 0.0,
    'Dice_WT_gini': 0.0,
    'Hausdorff95_ET_gini': 1.0,
    'Hausdorff95_TC_gini': 1.0,
    'Hausdorff95_WT_gini': 1.0,
    'cases_evaluated': 5,
    'submission_status': 'SCORED'
}
```